### PR TITLE
basic DB setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 PORT=3006
-MONGODB_URI=mongodb://localhost/project-resc-u-test
+MONGODB_URI=mongodb+srv://admin:1234@resc-u.okafj.mongodb.net/resc-u?retryWrites=true&w=majority

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-require("dotenv/config");
+require("dotenv").config();
 const path = require("path");
 const express = require("express");
 const app = express();

--- a/db/index.js
+++ b/db/index.js
@@ -1,13 +1,17 @@
 const mongoose = require("mongoose");
-const MONGO_URI = process.env.MONGODB_URI || "mongodb://localhost/project-resc-u-test";
+require("dotenv").config();
+
+const MONGO_URI = process.env.MONGODB_URI;
 
 mongoose
   .connect(MONGO_URI, {
     useNewUrlParser: true,
-    useUnifiedTopology: true
+    useUnifiedTopology: true,
   })
   .then((x) => {
-    console.log(`Connected to Mongo! Database name: "${x.connections[0].name}"`);
+    console.log(
+      `Connected to Mongo! Database name: "${x.connections[0].name}"`
+    );
   })
   .catch((err) => {
     console.error("Error connecting to mongo: ", err);


### PR DESCRIPTION
basic database setup

the DB has 3 users(all with 1234 as their password): 
- "admin": MONGODB atlas admin permissions
- "shelter": read & write permissions
- "adopter": read-only (maybe for them to signup they'd need write permissions?)

my thoughts are for the different users we make them connect to the DB with different strings
- admin: "mongodb+srv://admin:1234@resc-u.okafj.mongodb.net/resc-u?retryWrites=true&w=majority"
- shelter: "mongodb+srv://shelter:1234@resc-u.okafj.mongodb.net/resc-u?retryWrites=true&w=majority"
- adopter: "mongodb+srv://adopter:1234@resc-u.okafj.mongodb.net/resc-u?retryWrites=true&w=majority"

maybe it's unnecessary, but it would add an extra layer of protection I think